### PR TITLE
Introduce Zstandard codec

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ See. [AvroValueConverters](https://github.com/joker1007/embulk-formatter-avro/tr
 ## Configuration
 
 - **avsc**: avro schema (avsc) filepath (string, required)
-- **codec**: avro codec type (enum: `deflate`, `bzip2`, `xz`, `snappy`, optional)
-- **compression\_level**: avro codec compression level (integer, optional, for only `deflate` and `xz` codec)
+- **codec**: avro codec type (enum: `deflate`, `bzip2`, `xz`, `snappy`, `zstandard`, optional)
+- **compression\_level**: avro codec compression level (integer, optional, for only `deflate`, `xz` and `zstandard` codec)
 - **skip\_error\_record**: If you want to skip error record, set true (boolean, default: `false`)
 
 ## Example

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,5 @@
 plugins {
-    id "com.jfrog.bintray" version "1.1"
-    id "com.github.jruby-gradle.base" version "0.1.5"
+    id "com.github.jruby-gradle.base" version "0.1.17"
     id "java"
     id "checkstyle"
 }
@@ -15,17 +14,19 @@ configurations {
 
 version = "0.2.1"
 
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 dependencies {
-    compile  "org.embulk:embulk-core:0.8.15"
-    provided "org.embulk:embulk-core:0.8.15"
-    compile "org.apache.avro:avro:1.8.1"
+    compile  "org.embulk:embulk-core:0.9.23"
+    provided "org.embulk:embulk-core:0.9.23"
+    compile "org.apache.avro:avro:1.11.1"
+    compile "org.tukaani:xz:1.9"
+    compile "com.github.luben:zstd-jni:1.5.2-3"
     // compile "YOUR_JAR_DEPENDENCY_GROUP:YOUR_JAR_DEPENDENCY_MODULE:YOUR_JAR_DEPENDENCY_VERSION"
     testCompile "junit:junit:4.+"
-    testCompile  "org.embulk:embulk-core:0.8.15:tests"
-    testCompile  "org.embulk:embulk-standards:0.8.15"
+    testCompile  "org.embulk:embulk-core:0.9.23:tests"
+    testCompile  "org.embulk:embulk-standards:0.9.23"
 }
 
 task classpath(type: Copy, dependsOn: ["jar"]) {
@@ -37,7 +38,7 @@ clean { delete "classpath" }
 
 checkstyle {
     configFile = file("${project.rootDir}/config/checkstyle/checkstyle.xml")
-    toolVersion = '6.14.1'
+    toolVersion = '9.3'
 }
 checkstyleMain {
     configFile = file("${project.rootDir}/config/checkstyle/default.xml")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-bin.zip

--- a/src/main/java/org/embulk/formatter/avro/AvroFormatterPlugin.java
+++ b/src/main/java/org/embulk/formatter/avro/AvroFormatterPlugin.java
@@ -206,6 +206,11 @@ public class AvroFormatterPlugin
             public CodecFactory getCodecFactory(Optional<Integer> compressionLevel) {
                 return CodecFactory.bzip2Codec();
             }
+        },
+        ZSTANDARD {
+            public CodecFactory getCodecFactory(Optional<Integer> compressionLevel) {
+                return CodecFactory.zstandardCodec(compressionLevel.or(CodecFactory.DEFAULT_ZSTANDARD_LEVEL));
+            }
         };
 
         @JsonValue
@@ -227,6 +232,8 @@ public class AvroFormatterPlugin
                     return SNAPPY;
                 case "bzip2":
                     return BZIP2;
+                case "zstandard":
+                    return ZSTANDARD;
                 default:
                     throw new ConfigException(String.format("Unknown mode '%s'. Supported modes are single_column, multi_column", name));
             }

--- a/src/main/java/org/embulk/formatter/avro/converter/AvroMapConverter.java
+++ b/src/main/java/org/embulk/formatter/avro/converter/AvroMapConverter.java
@@ -1,9 +1,9 @@
 package org.embulk.formatter.avro.converter;
 
-import avro.shaded.com.google.common.collect.ImmutableMap;
 import org.apache.avro.Schema;
 import org.msgpack.value.Value;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public class AvroMapConverter extends AbstractAvroValueConverter {
@@ -21,32 +21,32 @@ public class AvroMapConverter extends AbstractAvroValueConverter {
 
         Map<Value, Value> map = value.asMapValue().map();
 
-        ImmutableMap.Builder<String, Object> builder = ImmutableMap.builder();
+        Map<String, Object> converted = new HashMap();
 
         for (Map.Entry<Value, Value> entry : map.entrySet()) {
             switch (entry.getValue().getValueType()) {
                 case STRING:
-                    builder.put(entry.getKey().toString(), elementConverter.stringColumn(entry.getValue().asStringValue().toString()));
+                    converted.put(entry.getKey().toString(), elementConverter.stringColumn(entry.getValue().asStringValue().toString()));
                     break;
                 case INTEGER:
-                    builder.put(entry.getKey().toString(), elementConverter.longColumn(entry.getValue().asIntegerValue().toLong()));
+                    converted.put(entry.getKey().toString(), elementConverter.longColumn(entry.getValue().asIntegerValue().toLong()));
                     break;
                 case FLOAT:
-                    builder.put(entry.getKey().toString(), elementConverter.doubleColumn(entry.getValue().asFloatValue().toDouble()));
+                    converted.put(entry.getKey().toString(), elementConverter.doubleColumn(entry.getValue().asFloatValue().toDouble()));
                     break;
                 case BOOLEAN:
-                    builder.put(entry.getKey().toString(), elementConverter.booleanColumn(entry.getValue().asBooleanValue().getBoolean()));
+                    converted.put(entry.getKey().toString(), elementConverter.booleanColumn(entry.getValue().asBooleanValue().getBoolean()));
                     break;
                 case ARRAY:
-                    builder.put(entry.getKey().toString(), elementConverter.jsonColumn(entry.getValue().asArrayValue()));
+                    converted.put(entry.getKey().toString(), elementConverter.jsonColumn(entry.getValue().asArrayValue()));
                     break;
                 case MAP:
-                    builder.put(entry.getKey().toString(), elementConverter.jsonColumn(entry.getValue().asMapValue()));
+                    converted.put(entry.getKey().toString(), elementConverter.jsonColumn(entry.getValue().asMapValue()));
                     break;
                 default:
                     throw new RuntimeException("Irregular Messagepack type");
             }
         }
-        return builder.build();
+        return converted;
     }
 }


### PR DESCRIPTION
This PR proposes introducing zstd codec to embulk-formatter-avro for improving storage efficiency and computational performance.
I tested the PR manually, as follows:

```
$ cat config.yml
exec:
  max_threads: 1
  min_output_tasks: 1

in:
    type: randomj
    rows: 1
    threads: 1
    primary_key: foo
    schema:
      - {name: foo, type: long}
      - {name: bar, type: string}
      - {name: baz, type: boolean}

out:
  type: file
  path_prefix: ./out_
  file_ext: avro
  formatter:
    type: avro
    avsc: schema.avsc
    codec: zstandard
    compression_level: 3
$ cat schema.avsc 
{"type": "record", "name": "output",
 "fields": [
     {"name": "foo", "type": "long"},
     {"name": "bar", "type": "string"},
     {"name": "baz", "type": "boolean"}
 ]
}
$ java -jar embulk-0.9.24.jar gem install ~/embulk-formatter-avro/pkg/embulk-formatter-avro-0.2.1.gem 

...

Successfully installed embulk-formatter-avro-0.2.1
1 gem installed
$ java -jar embulk-0.9.24.jar run config.yml 
2022-11-29 11:33:10.193 +0900: Embulk v0.9.24

...

2022-11-29 11:33:13.519 +0900 [INFO] (main): Committed.
2022-11-29 11:33:13.519 +0900 [INFO] (main): Next config diff: {"in":{},"out":{}}
$ java -jar avro-tools-1.11.1.jar getmeta out_000.00.avro 
22/11/29 11:33:38 WARN util.NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
avro.schema	{"type":"record","name":"output","fields":[{"name":"foo","type":"long"},{"name":"bar","type":"string"},{"name":"baz","type":"boolean"}]}
avro.codec	zstandard
$ java -jar avro-tools-1.11.1.jar tojson out_000.00.avro
22/11/29 11:35:12 WARN util.NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
{"foo":1,"bar":"QiKL9af0TVvgPxwcY7XiZrOihteWk6ER","baz":false}
```

This PR also upgrades some dependencies. For example, gradle is upgraded to 4.10.3 since 2.10 is so old that I failed to open the project in recent version of IntelliJ IDEA with the following error:

```
Unsupported Gradle. 
The project uses Gradle 2.10 which is incompatible with IntelliJ IDEA 2022.2.4.
```